### PR TITLE
`isConfirmed` Field for Manual Parking

### DIFF
--- a/__tests__/controllers/meterController.test.js
+++ b/__tests__/controllers/meterController.test.js
@@ -90,11 +90,11 @@ describe('Meter Tests', () => {
       .put(`/api/meter/${newMeter.id}`)
       .send({ isOccupied: false, licensePlate: 'NOTNOT' });
 
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.unitPrice).toEqual(newMeter.unitPrice);
-      expect(res.body.isOccupied).toEqual(false);
-      expect(res.body.id).toEqual(newMeter.id);
-      expect(res.body.parkingId).not.toBeTruthy();
+    expect(res.statusCode).toEqual(200);
+    expect(res.body.unitPrice).toEqual(newMeter.unitPrice);
+    expect(res.body.isOccupied).toEqual(false);
+    expect(res.body.id).toEqual(newMeter.id);
+    expect(res.body.parkingId).not.toBeTruthy();
   });
 
   it('401 meter is not occupied', async () => {
@@ -102,8 +102,23 @@ describe('Meter Tests', () => {
       .put(`/api/meter/${newMeter.id}`)
       .send({ isOccupied: false, licensePlate: '123321' });
 
-      expect(res.statusCode).toEqual(401);
-      expect(res.body.message).toEqual('Error: meter is not occupied');
+    expect(res.statusCode).toEqual(401);
+    expect(res.body.message).toEqual('Error: meter is not occupied');
+  });
+
+  /* ====================================================================================================================================================
+   */
+
+  it('200 isOccupied: true, isConfirmed: true (manual parking)', async () => {
+    const res = await api
+      .put(`/api/meter/${newMeter.id}`)
+      .send({ isOccupied: true, licensePlate: 'NOTNOT', isConfirmed: true });
+
+    expect(res.statusCode).toEqual(200);
+    expect(res.body.unitPrice).toEqual(newMeter.unitPrice);
+    expect(res.body.isOccupied).toEqual(true);
+    expect(res.body.id).toEqual(newMeter.id);
+    expect(res.body.parkingId).toBeTruthy();
   });
 
   afterAll(async done => {

--- a/controllers/meterController.js
+++ b/controllers/meterController.js
@@ -99,7 +99,7 @@ const updateStatus = async (req, res, next) => {
   if (!errors.isEmpty()) return next(new HttpError('Invalid inputs', 422));
 
   const { meterId } = req.params;
-  const { isOccupied, licensePlate } = req.body;
+  const { isOccupied, licensePlate, isConfirmed } = req.body;
   if (!meterId || !licensePlate)
     return next(new HttpError('Invalid inputs', 422));
 
@@ -141,7 +141,8 @@ const updateStatus = async (req, res, next) => {
       req,
       licensePlate,
       meterId,
-      savedMeter.unitPrice
+      savedMeter.unitPrice,
+      isConfirmed
     );
 
     if (!result.success)
@@ -165,7 +166,6 @@ const updateStatus = async (req, res, next) => {
     savedMeter.licensePlate = undefined;
     savedMeter.parkingId = undefined;
     savedMeter.cost = result.cost;
-    savedMeter.isConfirmed = false;
   }
 
   try {

--- a/models/meter.js
+++ b/models/meter.js
@@ -7,7 +7,6 @@ const meterSchema = new Schema(
     unitPrice: { type: Number, required: true },
     isOccupied: { type: Boolean, required: true, default: false },
     licensePlate: { type: String },
-    isConfirmed: { type: Boolean, default: false },
     parkingId: {
       type: mongoose.Schema.Types.ObjectId,
       ref: 'Parking',

--- a/models/parking.js
+++ b/models/parking.js
@@ -38,6 +38,7 @@ parkingSchema.set('toJSON', {
     delete returnedObject.__v;
     delete returnedObject.createdAt;
     delete returnedObject.updatedAt;
+    delete returnedObject.isConfirmed;
   },
 });
 

--- a/webhook/messageBuilder.js
+++ b/webhook/messageBuilder.js
@@ -18,11 +18,7 @@ const buildMeterStatusChangeMessage = savedMeter => {
     value: savedMeter.licensePlate ? savedMeter.licensePlate : 'None',
     inline: true,
   };
-  const isConfirmed = {
-    name: 'isConfirmed',
-    value: savedMeter.isConfirmed ? savedMeter.isConfirmed : 'None',
-    inline: true,
-  };
+
   const parkingId = {
     name: 'parkingId',
     value: savedMeter.parkingId ? savedMeter.parkingId : 'None',
@@ -41,7 +37,6 @@ const buildMeterStatusChangeMessage = savedMeter => {
     unitPrice,
     isOccupied,
     licensePlate,
-    isConfirmed,
     parkingId,
     cost,
   ];

--- a/webhook/webhook.js
+++ b/webhook/webhook.js
@@ -21,10 +21,12 @@ const parkingConfirmationHook = async savedParking => {
 };
 
 const sendHook = async (url, body) => {
-  try {
-    await axios.post(url, body);
-  } catch (exception) {
-    LOG.error('Discord webhook failed', exception);
+  if (process.env.NODE_ENV !== 'test') {
+    try {
+      await axios.post(url, body);
+    } catch (exception) {
+      LOG.error('Discord webhook failed', exception);
+    }
   }
 
   return;


### PR DESCRIPTION
# :ship: Pull Request

## :question: Purpose

Set `isConfirmed` field to `true` if it is in request body (`isConfirmed` is an **optional** field, used only when manually parking)

## :hammer: Validation Strategy

```
curl --location --request PUT 'http://localhost:8080/api/meter/<meterId>' \
--data-raw '{
    "isOccupied": true,
    "licensePlate": "ABCABC",
    "isConfirmed": true
}'

// 200
{
    "isOccupied": true,
    "unitPrice": 12,
    "licensePlate": "ABCABC",
    "parkingId": "6060eebb7847882474b99edc",
    "id": "603f12ee30c54218a0910f3d"
}
```

**Checking DB** will see `isConfirmed: true` for this newly created parking session
![image](https://user-images.githubusercontent.com/8460976/112767942-4f376f00-8fce-11eb-8f87-1c866f7779df.png)


## :tickets: Ticket(s)

Close #25 
